### PR TITLE
Change client-server communication model

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,49 @@
 use tokio::io::*;
 use tokio::net::*;
 
-pub async fn read_from_stream(stream: &mut TcpStream) -> Result<String> {
-    let mut buf: Vec<u8> = Vec::new();
-    loop {
-        let b = stream.read_u8().await?;
-        if b == b'\n' {
-            break;
+struct Header {
+    msg_length: u64,
+}
+
+impl Header {
+    fn new(msg: &[u8]) -> Self {
+        Self {
+            msg_length: msg.len() as u64,
         }
-        buf.push(b);
     }
-    let s: String = buf.into_iter().map(|b| b as char).collect();
-    Ok(s.trim().to_string())
+    
+    async fn read_header(stream: &mut TcpStream) -> Result<Self> {
+        Ok(Self {
+            msg_length: stream.read_u64().await?,
+        })
+    }
+
+    async fn write_header(&self, stream: &mut TcpStream) -> Result<()> {
+        stream.write_u64(self.msg_length).await
+    }
+
+}
+
+
+pub async fn read_from_stream(stream: &mut TcpStream) -> Result<String> {
+    let header = Header::read_header(stream).await?;
+    let mut msg_buf = Vec::with_capacity(header.msg_length as usize);
+
+    // SAFETY: Elements must be initializsed by read_exact
+    unsafe {
+        msg_buf.set_len(header.msg_length as usize);
+    }
+
+    stream.read_exact(msg_buf.as_mut_slice()).await?;
+
+    Ok(String::from_utf8_lossy(&msg_buf).to_string())
+
+
 }
 
 pub async fn write_to_stream<B: AsRef<[u8]>>(stream: &mut TcpStream, msg: B) -> Result<()> {
+    let msg = msg.as_ref();
+    Header::new(msg).write_header(stream).await?;
     stream.write_all(msg.as_ref()).await
 }
 


### PR DESCRIPTION
Better way to read and write messages over the network. By always sending the number of bytes in a message before sending the message